### PR TITLE
Fix missing import of time module

### DIFF
--- a/dojango/forms/widgets.py
+++ b/dojango/forms/widgets.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 
 from django.forms import *
 from django.utils import formats


### PR DESCRIPTION
The module is used in: "initial = datetime.time(*time.strptime(initial, input_format)[3:6])"
