### PR TITLE
Django 1.7 compatibility: Removed unused reference to django.utils.encoding.StrAndUnicode. StrAndU...

### DIFF
--- a/dojango/forms/widgets.py
+++ b/dojango/forms/widgets.py
@@ -3,7 +3,7 @@ import time
 
 from django.forms import *
 from django.utils import formats
-from django.utils.encoding import StrAndUnicode, force_unicode
+from django.utils.encoding import force_unicode
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 from django.forms.util import flatatt


### PR DESCRIPTION
...nicode no longer exists in Django 1.7+.
