### PR TITLE
Fix for dojo 1.10 and +

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.py[co]
+dojango/dojo-media/release

--- a/dojango/templates/dojango/base.html
+++ b/dojango/templates/dojango/base.html
@@ -31,7 +31,7 @@
 		<script type="text/javascript">
 			{# baseUrl setting is needed, if you want to combine a local with a remote build! #}
 			{% block _dojango_dj_config %}
-				var djConfig = {
+				var {% if DOJANGO.VERSION|version_upper_than:'1.6' %}dojoConfig{% else %}djConfig{% endif %} = {
 					'isDebug':{{ DOJANGO.DEBUG|json }},
 					'parseOnLoad':true,
 					'baseUrl':"{{ DOJANGO.DOJO_BASE_PATH }}"
@@ -39,7 +39,7 @@
 						,'dojoBlankHtmlUrl':"{{ DOJANGO.DOJANGO_URL }}/resources/blank.html"
 						,'dojoIframeHistoryUrl':"{{ DOJANGO.DOJANGO_URL }}/resources/blank.html"
 					{% endif %}
-					{% if DOJANGO.VERSION > '1.6' %}
+					{% if DOJANGO.VERSION|version_upper_than:'1.6' %}
 						,'paths':{'dojo': '{{ DOJANGO.DOJO_URL }}', 'dijit': '{{ DOJANGO.DIJIT_URL }}', 'dojox': '{{ DOJANGO.DOJOX_URL }}'}
 					{% else %}{% if DOJANGO.CDN_USE_SSL and not DOJANGO.IS_LOCAL %}
 						,'modulePaths':{'dojo': '{{ DOJANGO.DOJO_URL }}', 'dijit': '{{ DOJANGO.DIJIT_URL }}', 'dojox': '{{ DOJANGO.DOJOX_URL }}'}

--- a/dojango/templates/dojango/base_i18n.html
+++ b/dojango/templates/dojango/base_i18n.html
@@ -1,5 +1,5 @@
 {% extends "dojango/base.html" %}
-
+{% load dojango_filters %}
 {% if not LANGUAGE_CODE %}
     {% load i18n %}
     {% get_current_language as LANGUAGE_CODE %}
@@ -10,6 +10,6 @@
 {% block _dojango_meta_content_lang %}<meta http-equiv="content-language" content="{{ LANGUAGE_CODE }}" />{% endblock %}
 {% block _dojango_post_dj_config %}
 <script type="text/javascript">
-    {% if DOJANGO.VERSION > '1.6' %}dojoConfig{% else %}djConfig{% endif %}['locale'] = "{{ LANGUAGE_CODE }}";
+    {% if DOJANGO.VERSION|version_upper_than:'1.6' %}dojoConfig{% else %}djConfig{% endif %}['locale'] = "{{ LANGUAGE_CODE }}";
 </script>
 {% endblock %}

--- a/dojango/templates/dojango/base_i18n.html
+++ b/dojango/templates/dojango/base_i18n.html
@@ -10,6 +10,6 @@
 {% block _dojango_meta_content_lang %}<meta http-equiv="content-language" content="{{ LANGUAGE_CODE }}" />{% endblock %}
 {% block _dojango_post_dj_config %}
 <script type="text/javascript">
-    djConfig['locale'] = "{{ LANGUAGE_CODE }}";
+    {% if DOJANGO.VERSION > '1.6' %}dojoConfig{% else %}djConfig{% endif %}['locale'] = "{{ LANGUAGE_CODE }}";
 </script>
 {% endblock %}

--- a/dojango/templates/dojango/include.html
+++ b/dojango/templates/dojango/include.html
@@ -11,7 +11,7 @@
 </style>
 <script type="text/javascript">
     {# baseUrl setting is needed, if you want to combine a local with a remote build! #}
-	var djConfig = {
+	var {% if DOJANGO.VERSION|version_upper_than:'1.6' %}dojoConfig{% else %}djConfig{% endif %} = {
 		'isDebug':{{ DOJANGO.DEBUG|json }},
 		'parseOnLoad':true,
 		'baseUrl':"{{ DOJANGO.DOJO_BASE_PATH }}"
@@ -19,7 +19,7 @@
 			,'dojoBlankHtmlUrl':"{{ DOJANGO.DOJANGO_URL }}/resources/blank.html"
 			,'dojoIframeHistoryUrl':"{{ DOJANGO.DOJANGO_URL }}/resources/blank.html"
 		{% endif %}
-		{% if DOJANGO.VERSION > '1.6' %}
+		{% if DOJANGO.VERSION|version_upper_than:'1.6' %}
 			,'paths':{'dojo': '{{ DOJANGO.DOJO_URL }}', 'dijit': '{{ DOJANGO.DIJIT_URL }}', 'dojox': '{{ DOJANGO.DOJOX_URL }}'}
 		{% else %}{% if DOJANGO.CDN_USE_SSL and not DOJANGO.IS_LOCAL %}
 			,'modulePaths':{'dojo': '{{ DOJANGO.DOJO_URL }}', 'dijit': '{{ DOJANGO.DIJIT_URL }}', 'dojox': '{{ DOJANGO.DOJOX_URL }}'}

--- a/dojango/templates/dojango/include_i18n.html
+++ b/dojango/templates/dojango/include_i18n.html
@@ -9,6 +9,6 @@
 
 {% block _dojango_post_dj_config %}
 <script type="text/javascript">
-    djConfig['locale'] = "{{ LANGUAGE_CODE }}";
+    {% if DOJANGO.VERSION > '1.6' %}dojoConfig{% else %}djConfig{% endif %}['locale'] = "{{ LANGUAGE_CODE }}";
 </script>
 {% endblock %}

--- a/dojango/templates/dojango/include_i18n.html
+++ b/dojango/templates/dojango/include_i18n.html
@@ -9,6 +9,6 @@
 
 {% block _dojango_post_dj_config %}
 <script type="text/javascript">
-    {% if DOJANGO.VERSION > '1.6' %}dojoConfig{% else %}djConfig{% endif %}['locale'] = "{{ LANGUAGE_CODE }}";
+    {% if DOJANGO.VERSION|version_upper_than:'1.6' %}dojoConfig{% else %}djConfig{% endif %}['locale'] = "{{ LANGUAGE_CODE }}";
 </script>
 {% endblock %}

--- a/dojango/templates/dojango/test.html
+++ b/dojango/templates/dojango/test.html
@@ -1,8 +1,9 @@
 {% extends "dojango/base.html" %}
+{% load dojango_filters %}
 
 {% block dojango_post_dj_config %}
 	<script>
-		djConfig.parseOnLoad = false;
+		{% if DOJANGO.VERSION|version_upper_than:'1.6' %}dojoConfig{% else %}djConfig{% endif %}.parseOnLoad = false;
 	</script>
 {% endblock %}
 

--- a/dojango/templatetags/dojango_filters.py
+++ b/dojango/templatetags/dojango_filters.py
@@ -1,9 +1,14 @@
 from django.template import Library
 
-from dojango.util import json_encode
+from dojango.util import json_encode, version_cmp
 
 register = Library()
 
 @register.filter
 def json(input):
     return json_encode(input)
+
+@register.filter
+def version_upper_than(value, arg):
+    """Test if a version string is upper than the one given as argument."""
+    return version_cmp(value, arg) > 0

--- a/dojango/util/__init__.py
+++ b/dojango/util/__init__.py
@@ -1,6 +1,7 @@
 import os
 import datetime
 from decimal import Decimal
+import re
 
 from django import VERSION as django_version
 if django_version >= (1, 5, 0):
@@ -254,3 +255,9 @@ def is_number(s):
     except ValueError:
         pass
     return False
+
+def version_cmp(version1, version2):
+    def normalize(v):
+        return [int(x) for x in re.sub(r'(\.0+)*$','', v).split(".")]
+    return cmp(normalize(version1), normalize(version2))
+

--- a/dojango/util/config.py
+++ b/dojango/util/config.py
@@ -1,6 +1,8 @@
 from dojango.conf import settings # using the app-specific settings
 from dojango.util import dojo_collector
 from dojango.util import media
+from dojango.util import version_cmp
+
 
 class Config:
 
@@ -52,7 +54,7 @@ class Config:
         ret['THEME_CSS_URL'] = self.theme_css_url()
         ret['THEME'] = settings.DOJO_THEME
         ret['BASE_MEDIA_URL'] = settings.BASE_MEDIA_URL
-        ret['DOJO_BASE_PATH'] = self.version > '1.6' and self.dojo_base_path() or '%s/dojo/' % self.dojo_base_path()
+        ret['DOJO_BASE_PATH'] = version_cmp(self.version, '1.6') > 0 and self.dojo_base_path() or '%s/dojo/' % self.dojo_base_path()
         ret['DOJO_URL'] = self.dojo_url()
         ret['DIJIT_URL'] = self.dijit_url()
         ret['DOJOX_URL'] = self.dojox_url()


### PR DESCRIPTION
Version comparision using simple string doesn't work between '1.6' and '1.10'  ('1.6' > '1.10'). 
This patch ensure that we can always versions numbers : 
    \* 1.6 < 1.10

This allows to have 'dojoConfig' instead 'djConfig' with versions 1.10 and upper.
